### PR TITLE
UBL changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     }
   ],
   "require": {
-    "drupal/migrate_plus": "^4",
+    "drupal/migrate_plus": "^5",
     "jonathangreen/tuque": "dev-master"
   },
   "require-dev": {

--- a/migrate_7x_claw.info.yml
+++ b/migrate_7x_claw.info.yml
@@ -2,7 +2,7 @@ type: module
 name: Migrate Islandora 7.x to CLAW
 description: 'Migration setup for migrating from an Islandora 7.x instance to CLAW.'
 package: Islandora
-core: 8.x
+core_version_requirement: ^8 || ^9
 dependencies:
   - drupal:migrate
   - migrate_plus:migrate_plus

--- a/modules/islandora_migrate_7x_claw_feature/islandora_migrate_7x_claw_feature.info.yml
+++ b/modules/islandora_migrate_7x_claw_feature/islandora_migrate_7x_claw_feature.info.yml
@@ -1,7 +1,7 @@
 name: 'Migrate 7x Claw Feature'
 description: 'Migration configuration for moving to Islandora CLAW from 7.x'
 type: module
-core: 8.x
+core_version_requirement: ^8 || ^9
 dependencies:
   - migrate_plus
   - migrate_7x_claw

--- a/src/Form/MIGRATE7XCLAWSettingsForm.php
+++ b/src/Form/MIGRATE7XCLAWSettingsForm.php
@@ -138,8 +138,10 @@ class MIGRATE7XCLAWSettingsForm extends ConfigFormBase {
       $islandora_objects_config->set('source.authentication.password', $form_state->getValue('oldfedorapsswd'));
       $islandora_person_config->set('source.authentication.password', $form_state->getValue('oldfedorapsswd'));
       $islandora_subject_config->set('source.authentication.password', $form_state->getValue('oldfedorapsswd'));
-      $islandora_files_config->set('process.uri.settings.authentication.password', $form_state->getValue('oldfedorapsswd'));
-    }
+      #      $islandora_files_config->set('process.uri.settings.authentication.password', $form_state->getValue('oldfedorapsswd'));
+      //File needs a special authentication configuration to pass to Guzzle.
+      $islandora_files_config->set('process.uri.guzzle_options.auth', [$form_state->getValue('oldfedorausername'), $form_state->getValue('oldfedorapsswd')]);
+   }
 
     $config->set('solr-endpoint-url', $form_state->getValue('solr-endpoint-url'));
     $islandora_audit_file_config->set('source.solr_base_url', $form_state->getValue('solr-endpoint-url'));

--- a/src/Plugin/migrate/process/ArrayWithValue.php
+++ b/src/Plugin/migrate/process/ArrayWithValue.php
@@ -59,7 +59,7 @@ use Drupal\migrate\Row;
  * Casting from object to array is supported.
  * 
  * @MigrateProcessPlugin(
- *   id = "array_with_value"
+ *   id = "array_with_value",
  *   handle_multiples = TRUE
  * )
  */

--- a/src/Plugin/migrate/process/ArrayWithValue.php
+++ b/src/Plugin/migrate/process/ArrayWithValue.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace Drupal\migrate_7x_claw\Plugin\migrate\process;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\migrate\MigrateException;
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\Row;
+
+/**
+ * This plugin checks if the input value is an array containing specific values.
+ * If it is only the value, it is wrapped in an array.
+ * If it is not an array containing the value, the value can be cast in the necessary value.
+ *
+ * For example, the following input:
+ * @code
+ *   'test1'
+ * @endcode
+ * is tranformed to:
+ * @code
+ * array(
+ *  0 => 'test1'
+ * )
+ * @endcode
+ * using the following settings:
+ * @code
+ * my_field:
+ *   source: my_source
+ *   plugin: array_with_value
+ *   value_type: string
+ * @endcode
+ *
+ * But the following input:
+ * @code
+ * array(
+ *   0 => 'test1'
+ * )
+ * @endcode
+ * is tranformed to:
+ * @code
+ * array(
+ *   array(
+ *     0 => 'test1'
+ *   )
+ * )
+ * @endcode
+ * using the following settings:
+ * @code
+ * my_field:
+ *   source: my_source
+ *   plugin: array_with_value
+ *   value_type: array
+ * @endcode
+ * but stays the same (is untouched) when using value_type: string
+ *
+ * The following value_types are supported: 
+ * array, string, int (or integer), float (or double), bool (or boolean), object.
+ * Casting from object to array is supported.
+ * 
+ * @MigrateProcessPlugin(
+ *   id = "array_with_value"
+ *   handle_multiples = TRUE
+ * )
+ */
+class ArrayWithValue extends ProcessPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+
+    // Only process non-empty values.
+    if (empty($value)) {
+      return NULL;
+    }
+
+    $value_type = $this->configuration['value_type'] ?? 'anything';
+
+    // Check if it is already an array.
+    if (is_array($value)) {
+      switch ($value_type) {
+        case "array":
+          // Check if value is a non-associative array, should have a value at the 0 index.
+          if (array_key_exists(0, $value)) {
+            // Cast containing objects to arrays if only objects.
+            $containsObjects = TRUE;
+            foreach ($value as $v) {
+              if (!is_object($v)) {
+                $containsObjects = FALSE;
+                break;
+              }
+            }
+            if ($containsObjects) {
+              // $value only contains objects, so cast them.
+              $newarray = [];
+              foreach ($value as $k => $v) {
+                $old_type = gettype($v);
+                if (!settype($v, $value_type)) {
+                  throw new MigrateException("Value '$value' of type '$old_type' cannot be cast to type '$value_type'.");
+                }
+                $newarray[$k] = $v;
+              }
+              $value = $newarray;
+            }
+            else {
+              // Check if all containing values are arrays.
+              $containsArrays = TRUE;
+              foreach ($value as $v) {
+                if (!is_array($v)) {
+                  $containsArrays = FALSE;
+                  break;
+                } 
+              }
+              // $value does not only contain arrays, so wrap it in an array.
+              if (!$containsArrays) {
+                $value = [$value];
+              }
+            }
+          }
+          else {
+            // $value is an associative array, so wrap it in an array.
+            $value = [$value];
+          }
+          break;
+        case "anything":
+          break;
+        case "object":
+          // Only cast to object if $value only contains arrays.
+          $containsArrays = TRUE;
+          foreach ($value as $v) {
+            if (!is_array($v)) {
+              $containsArrays = FALSE;
+              break;
+            } 
+          }
+          if (!$containsArrays) {
+            throw new MigrateException("Value '$value' of type that is not array is not cast to object.");
+          }
+          // Pass through.
+        case "string":
+        case "int":
+        case "integer":
+        case "float":
+        case "double":
+        case "bool":
+        case "boolean":
+          $newarray = [];
+          foreach ($value as $k => $v) {
+            $old_type = gettype($v);
+            if (!settype($v, $value_type)) {
+              throw new MigrateException("Value '$value' of type '$old_type' cannot be cast to type '$value_type'.");
+            }
+            $newarray[$k] = $v;
+          }
+          $value = $newarray;
+          break;
+        default:
+          throw new MigrateException("Cannot cast to value_type '$value_type'.");
+          break;
+      }
+    }
+    else {
+      $old_type = gettype($value);
+      switch ($value_type) {
+        case "array":
+          if ($old_type !== 'object') {
+            throw new MigrateException("Value '$value' of type '$old_type' is not cast to array.");
+          }
+          // Pass through.
+        case "object":
+          if ($old_type !== 'array') {
+            throw new MigrateException("Value '$value' of type '$old_type' is not cast to object.");
+          }
+          // Pass through.
+        case "string":  
+        case "int":  
+        case "integer":
+        case "float":
+        case "double":
+        case "bool":
+        case "boolean":
+          if (!settype($value, $value_type)) {
+            throw new MigrateException("Value '$value' of type '$old_type' cannot be cast to type '$value_type'.");
+          }
+          break;
+        case "anything":
+          break;
+        default:
+          throw new MigrateException("Cannot cast to value_type '$value_type'.");
+          break;
+      }
+      $value = [$value];
+    }
+
+    return $value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function multiple() {
+    return TRUE;
+  }
+
+}

--- a/src/Plugin/migrate/process/ArrayZip.php
+++ b/src/Plugin/migrate/process/ArrayZip.php
@@ -86,7 +86,7 @@ use Drupal\migrate\Row;
  * If there are less keys than source values, than some of the source values will not be used.
  * 
  * @MigrateProcessPlugin(
- *   id = "array_zip"
+ *   id = "array_zip",
  *   handle_multiples = TRUE
  * )
  */

--- a/src/Plugin/migrate/process/ArrayZip.php
+++ b/src/Plugin/migrate/process/ArrayZip.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Drupal\migrate_7x_claw\Plugin\migrate\process;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\migrate\MigrateException;
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\Row;
+
+/**
+ * This plugin zips two or more arrays into each other.
+ *
+ * For example, the following input:
+ * @code
+ * array(
+ *   array(1, 2, 3),
+ *   array('a', 'b', 'c'),
+ * )
+ * @endcode
+ * is tranformed to:
+ * @code
+ * array(
+ *  array(1, 'a'),
+ *  array(2, 'b'),
+ *  array(3, 'c'),
+ * )
+ * @endcode
+ *
+ * It is also possible to give specific keys.
+ * Assuming first is array(1, 2, 3) and second is array('a', 'b', 'c')
+ * and the following configuration:
+ * @code
+ * plugin: array_zip
+ * source:
+ *  - first
+ *  - second
+ * keys:
+ *  - number
+ *  - letter
+ * @endcode
+ * would give the following output:
+ * @code
+ * array(
+ *   array(
+ *     'number' => 1,
+ *     'letter' => 'a',
+ *   ),
+ *   array(
+ *     'number' => 2,
+ *     'letter' => 'b',
+ *   ),
+ *   array(
+ *     'number' => 3,
+ *     'letter' => 'b',
+ *   ),
+ * )
+ * @endcode
+ *
+ * If the source is an array of associative arrays, the keys can also be used
+ * to retrieve the values from the associative arrays.
+ * For example, if first is array('number' => 1) and second is array('letter' => 'a')
+ * then the output will be (with the above configuration:
+ * @code
+ * array(
+ *   array(
+ *     'number' => 1,
+ *     'letter' => 'a',
+ *   ),
+ * )
+ * @endcode
+ * The source cannot be an associative array itself.
+ *
+ * Also, this can be used to build a associative array with single values:
+ * Input first and second can be string values, say "first" and "second".
+ * Then this would give the following output with the same configuration:
+ * @code
+ * array(
+ *   array(
+ *     'number' => 'first',
+ *     'letter' => 'second',
+ *   ),
+ * )
+ * @endcode
+ *
+ * If there are less keys than source values, than some of the source values will not be used.
+ * 
+ * @MigrateProcessPlugin(
+ *   id = "array_zip"
+ *   handle_multiples = TRUE
+ * )
+ */
+class ArrayZip extends ProcessPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+
+    // Only process non-empty values.
+    if (empty($value)) {
+      return NULL;
+    }
+    if (!is_array($value)) {
+      $type = gettype($value);
+      throw new MigrateException("Source for array_zip should be an array, but is '$type'.");
+    }
+    if (isset($this->configuration['keys']) && !is_array($this->configuration['keys'])) {
+      $type = gettype($this->configuration['keys']);
+      throw new MigrateException("Keys for array_zip should be an array, but is '$type'.");
+    }
+
+    $keys = $this->configuration['keys'] ?? range(0, count($value));
+
+    $output = [];
+    for ($i = 0; TRUE; $i++) {
+      $item = [];
+      foreach ($keys as $index => $key) {
+        if (array_key_exists($index, $value)) {
+          if (!is_array($value[$index]) && ($i === 0)) {
+            $item[$key] = $value[$index];
+          }
+          elseif (array_key_exists($i, $value[$index])) {
+            $item[$key] = $value[$index][$i];
+          }
+          elseif (array_key_exists($key, $value[$index])) {
+            $item[$key] = $value[$index][$key];
+          }
+        }
+      }
+      if (empty($item)) {
+        break;
+      }
+      $output[] = $item;
+    }
+
+    return $output;
+  }
+
+
+  /**
+   * {@inheritdoc}
+   */
+  public function multiple() {
+    return TRUE;
+  }
+
+}

--- a/src/Plugin/migrate/process/XmlXPath.php
+++ b/src/Plugin/migrate/process/XmlXPath.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Drupal\migrate_7x_claw\Plugin\migrate\process;
+
+use Drupal\migrate_plus\Plugin\migrate_plus\data_parser\XmlTrait;
+use Drupal\migrate\MigrateException;
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\Row;
+
+/**
+ * This plugin retrieves a piece or pieces from XML via XPath.
+ *
+ * Use in the following manner:
+ * @code
+ * my_field:
+ *   plugin: xml_xpath
+ *   source:
+ *     - my_xml
+ *     - my_xpath
+ * @endcode
+ * 
+ * @MigrateProcessPlugin(
+ *   id = "xml_xpath"
+ * )
+ */
+class XmlXPath extends ProcessPluginBase {
+  use XmlTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+
+    // Only process non-empty values.
+    if (empty($value)) {
+      return NULL;
+    }
+
+    $old_type = gettype($value);
+    if (!is_array($value)) {
+      throw new MigrateException("Value '$value' is not an array, but '$old_type'.");
+    }
+    if (count($value) != 2) {
+      throw new MigrateException("Value '$value' is not an array with 2 values, but has " . count($value) . " values.");
+    }
+    $value_type = $this->configuration['value_type'] ?? 'string';
+
+    $result = [];
+    
+    [$xml, $xpath] = $value;
+  
+    if (is_string($xml)) {
+      // Parse the xml in the value.
+      libxml_use_internal_errors(true);
+      $error = '';
+      try {
+        $xml = new \SimpleXMLElement($xml);
+      }
+      catch (\Exception $e) {
+        $error = $e->getMessage() . "\n";
+      }
+      foreach (libxml_get_errors() as $libxml_err) {
+        $error .= self::parseLibXmlError($libxml_err) . "\n";
+      }
+      if ($error) {
+        throw new MigrateException("Error while parsing xml: $error");
+      }
+    }
+    elseif ($xml instanceof \SimpleXMLElement) {
+      // $xml is already the right kind!
+    }
+    else {
+      $type = gettype($xml);
+      throw new MigrateException("Xml of type '$type' cannot be handled.");
+    }
+
+    $this->registerNamespaces($xml);
+
+    $new_values = $xml->xpath($xpath);
+    if (!is_array($new_values)) {
+      throw new MigrateException(t("Error retrieving value from Xml with XPath @xpath.", ['@xpath' => $xpath]));
+    }
+
+    foreach ($new_values as $new_value) {
+      $result[] = trim((string)$new_value);
+    }
+    return $result;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function multiple() {
+    return TRUE;
+  }
+
+}

--- a/src/Plugin/migrate/source/Islandora.php
+++ b/src/Plugin/migrate/source/Islandora.php
@@ -425,7 +425,7 @@ class Islandora extends SourcePluginExtension {
     $params['start'] = 0;
     $params['fl'] = 'PID';
     $params['q'] = $this->q;
-    $escaped_value = str_replace(['"', '&'], ['\\"', '%26'], $value);
+    $escaped_value = str_replace(['"', '&', '#'], ['\\"', '%26', '%23'], $value);
     $params['fq'] = $this->unique_field . ':"' . $escaped_value . '"';
     $params['wt'] = 'json';
     return $this->solrBase . "/select?" . build_query($params, FALSE);

--- a/src/Plugin/migrate_plus/data_fetcher/LoadedFOXML.php
+++ b/src/Plugin/migrate_plus/data_fetcher/LoadedFOXML.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Drupal\migrate_7x_claw\Plugin\migrate_plus\data_fetcher;
+
+use Drupal\migrate_plus\Plugin\migrate_plus\data_fetcher\Http;
+use Drupal\migrate\MigrateException;
+use GuzzleHttp\Psr7\Utils;
+
+/**
+ * Obtain FOXML data for migration and load managed content as in-line content.
+ *
+ * @DataFetcher(
+ *   id = "loaded_foxml",
+ *   title = @Translation("Loaded FOXML")
+ * )
+ */
+class LoadedFOXML extends Http {
+
+  use \Drupal\migrate_plus\Plugin\migrate_plus\data_parser\XmlTrait;
+
+  /**
+   * The base URL of the Fedora repo.
+   *
+   * @var string
+   */
+  private $fedoraBase;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+
+    if (!isset($configuration['fedora_base_url'])) {
+      throw new MigrateException("Islandora source plugin requires a \"fedora_base_url\" be defined.");
+    }
+    $this->fedoraBase = rtrim($configuration['fedora_base_url'], '/');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getResponseContent($url) {
+    $response = $this->getResponse($url);
+    $body = $response->getBody();
+    if ($body && $this->isFedoraObjectXmlUrl($url)) {
+      $did_change = FALSE;
+      $digital_object = new \SimpleXMLElement($body);
+      $this->registerNamespaces($digital_object);
+      $digital_object = $digital_object->xpath('/foxml:digitalObject');
+      if (!is_array($digital_object) || count($digital_object) == 0) {
+        throw new MigrateException(t("Error retrieving digital object."));
+      }
+      if (count($digital_object) > 1) {
+        throw new MigrateException(t("Error retrieving single digital object, found !c digital objects.", ['!c' => count($digital_object)]));
+      }
+      $digital_object = $digital_object[0]; 
+      $pid = $digital_object['PID'];
+      $managed_datastreams = $digital_object->xpath('foxml:datastream[@CONTROL_GROUP="M"][@STATE="A"]');
+      if (!is_array($managed_datastreams)) {
+        throw new MigrateException(t("Error retrieving managed datastreams."));
+      }
+      foreach ($managed_datastreams as $managed_datastream) {
+        $dsid = $managed_datastream['ID'];
+        $versionsxpath = 'foxml:datastreamVersion[@MIMETYPE="text/xml" or @MIMETYPE="application/xml" or @MIMETYPE="application/rdf+xml"]';
+        if (TRUE) {
+          $versionsxpath .= '[last()]';
+        }
+        $versions = $managed_datastream->xpath($versionsxpath);
+        if (!is_array($versions)) {
+          throw new MigrateException(t("Error retrieving versions of managed datastreams."));
+        }
+        foreach ($versions as $version) {
+          $created = $version['CREATED'];
+          $url = "{$this->fedoraBase}/objects/{$pid}/datastreams/{$dsid}/content?format=xml&asOfDateTime=$created";
+          $dsxml = $this->getResponseContent($url)->getContents();
+          if ($dsxml) {
+            $dsxml = preg_replace('/^<\\?xml.*?\\?>/',  '', $dsxml);
+            $domversion = dom_import_simplexml($version);
+            $domxmlcontent = $domversion->ownerDocument->createElementNS('info:fedora/fedora-system:def/foxml#', 'foxml:xmlContent');
+            $domversion->appendChild($domxmlcontent);
+            $fragment = $domversion->ownerDocument->createDocumentFragment();
+            $fragment->appendXML($dsxml);
+
+            $domxmlcontent->appendChild($fragment);
+            $managed_datastream['CONTROL_GROUP'] = 'X';
+            $did_change = TRUE;
+          }
+        }
+      }
+      if ($did_change) {
+        $newXml = $digital_object->saveXML();
+        $body = Utils::streamFor($newXml);
+      }
+    }
+    return $body;
+  }
+
+  function isFedoraObjectXmlUrl($url) {
+    $objXml = 'objectXML';
+    return (substr($url, 0, strlen($this->fedoraBase)) === $this->fedoraBase) && (substr($url, -strlen($objXml)) === $objXml);
+  }
+}

--- a/src/Plugin/migrate_plus/data_parser/AuthenticatedXml.php
+++ b/src/Plugin/migrate_plus/data_parser/AuthenticatedXml.php
@@ -35,11 +35,20 @@ class AuthenticatedXml extends SimpleXml {
    */
   protected function fetchNextRow() {
     $target_element = array_shift($this->matches);
+    if (is_null($target_element)) {
+      return;
+    }
     // If we've found the desired element, populate the currentItem and
     // currentId with its data.
+    $this->registerNamespaces($target_element);
+    $this->currentItem = [];
     if ($target_element !== FALSE && !is_null($target_element)) {
       foreach ($this->fieldSelectors() as $field_name => $xpath) {
-        foreach ($target_element->xpath($xpath) as $value) {
+        $values = $target_element->xpath($xpath);
+        if (!is_array($values)) {
+          throw new MigrateException(t("Error retrieving field @field with XPath @xpath.", ['@field' => $field_name, '@xpath' => $xpath]));
+        }
+        foreach ($values as $value) {
           if ($value->children() && !trim((string) $value)) {
             $this->currentItem[$field_name] = $value;
           }

--- a/src/Plugin/migrate_plus/data_parser/AuthenticatedXml.php
+++ b/src/Plugin/migrate_plus/data_parser/AuthenticatedXml.php
@@ -50,7 +50,12 @@ class AuthenticatedXml extends SimpleXml {
         }
         foreach ($values as $value) {
           if ($value->children() && !trim((string) $value)) {
-            $this->currentItem[$field_name] = $value;
+            if ($value->children() == $value) {
+              $this->currentItem[$field_name][] = (string) $value;
+            }
+            else {
+              $this->currentItem[$field_name] = $value;
+            }
           }
           elseif (!trim((string) $value)){
             $this->currentItem[$field_name][] = $value->asXML();

--- a/src/Plugin/migrate_plus/data_parser/SolrDatastream.php
+++ b/src/Plugin/migrate_plus/data_parser/SolrDatastream.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace Drupal\migrate_7x_claw\Plugin\migrate_plus\data_parser;
+
+use Drupal\migrate\MigrateException;
+use Drupal\migrate_plus\DataParserPluginBase;
+use function GuzzleHttp\Psr7\build_query;
+
+/**
+ * Obtain datastream info from Solr.
+ *
+ * @DataParser(
+ *   id = "solr_datastreams",
+ *   title = @Translation("Solr_datastreams")
+ * )
+ *
+ * The field selector is a Solr field where DSID is replaced by the actual DSID.
+ *
+ * This will auto-populate the following fields
+ *  PID -> PID of the fedora object
+ *  PID_DSID -> a concatenated ID for use in media <-> file matching.
+ *
+ * It also will populate with the datastream ID any field with a selector of
+ * DSID.
+ */
+class SolrDatastream extends DataParserPluginBase {
+
+  /**
+   * The base URL for the Solr instance.
+   *
+   * @var string
+   */
+  private $solrBase;
+
+  /**
+   * Solr datastreams field.
+   *
+   * @var string
+   */
+  private $solrDatastreamsField;
+
+  /**
+   * Exclude datastreams.
+   *
+   * @var array
+   */
+  private $excludeDatastreams;
+
+  /**
+   * The current datastreams to view.
+   *
+   * @var array
+   */
+  private $datastreams;
+
+  /**
+   * The PID for currently loaded object.
+   *
+   * @var string
+   */
+  private $PID;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+
+    if (!isset($configuration['solr_base_url'])) {
+      throw new MigrateException("Solr datastream data_parser plugin requires a \"solr_base_url\" be defined.");
+    }
+    $this->solrBase = rtrim($configuration['solr_base_url'], '/');
+    $this->solrDatastreamsField = $configuration['datastream_solr_field'] ?? 'fedora_datastreams_ms';
+    $this->excludeDatastreams = $configuration['exclude_datastreams'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function openSourceUrl($url) {
+    $this->datastreams = [];
+    $this->PID = NULL;
+    $this->solrdoc = NULL;
+   
+    if (substr($url, 0, strlen($this->solrBase)) === $this->solrBase) {
+      // Is a Solr query url
+      $query = $url . '&' . build_query(['rows' => 1, 'start' => 0], FALSE); 
+      if (!preg_match('~q=PID%3A"([^"]+)"~', $url, $match)) {
+        return FALSE;
+      }
+      $pid = $match[1];
+    }
+    else {
+      // We expect PIDs or Fedora object URLs.
+      if (!preg_match('~^(?>' . preg_quote($this->baseUrl) . 'objects/)([^:/]+:[^:/]+)~', $url, $match)) {
+        return FALSE;
+      }
+      $pid = $match[1];
+
+      $query = $this->getQuery($pid);
+    }
+
+    $result = $this->getDataFetcherPlugin()->getResponseContent($query)->getContents();
+    $body = json_decode($result, TRUE);
+    $count = intval($body['response']['numFound']);
+    if ($count === 1 && isset($body['response']['docs'][0][$this->solrDatastreamsField])) {
+      $this->PID = $pid;
+      $solrdoc = $body['response']['docs'][0];
+      $excludeDSIDs = array_combine($this->excludeDatastreams, $this->excludeDatastreams); 
+ 
+      foreach ($solrdoc[$this->solrDatastreamsField] as $dsid) {
+        if (isset($excludeDSIDs[$dsid])) {
+          continue;
+        }
+        $this->datastreams[$dsid] = ['DSID' => $dsid];
+        foreach ($this->fieldSelectors() as $field_name => $property_name) {
+          $solrfield = str_replace('DSID', $dsid, $property_name);
+          if (isset($solrdoc[$solrfield]) && !isset($this->datastreams[$dsid][$field_name])) {
+            $this->datastreams[$dsid][$field_name] = $solrdoc[$solrfield];
+          }
+        }
+      }
+      return TRUE;
+    }
+     
+    return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function fetchNextRow() {
+    $datastream = array_shift($this->datastreams);
+
+    if ($datastream) {
+      $this->currentItem['PID'] = $this->PID;
+      foreach ($this->fieldSelectors() as $field_name => $property_name) {
+        $this->currentItem[$field_name] = $datastream[$field_name];
+      }
+      if (isset($datastream['DSID'])) {
+        $this->currentItem['PID_DSID'] = $this->currentItem['PID'] . '_' . $datastream['DSID'];
+      }
+      // Reduce single-value results to scalars.
+      foreach ($this->currentItem as $field_name => $values) {
+        if (is_array($values) && count($values) == 1) {
+          $this->currentItem[$field_name] = reset($values);
+        }
+      }
+    }
+  }
+
+  /**
+   * Update the configuration for the dataparserplugin.
+   *
+   * The XML dataParserPlugin assumes you give it all the URLs to start,
+   * but I am dynamically generating them based on the batch.
+   *
+   * @param array|string $urls
+   *   New array of URLs to add to the FedoraDatastream processor.
+   */
+  public function updateUrls($urls) {
+    if (!is_array($urls)) {
+      $urls = [$urls];
+    }
+    $this->urls = $urls;
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * Islandora Source can provide 0 urls, we need to exit or it throws an
+   * error.
+   */
+  protected function nextSource() {
+    if (count($this->urls) == 0) {
+      return FALSE;
+    }
+    return parent::nextSource();
+  }
+
+  /**
+   * Generate a Solr query string.
+   *
+   * @param string $pid
+   *   The PID to search for.
+   *
+   * @return string
+   *   The Full query URL.
+   */
+  private function getQuery($pid, $additionalFields = NULL) {
+    $params = [];
+    $params['rows'] = 1;
+    $params['start'] = 0;
+    $params['q'] = "PID:\"$pid\"";
+    if ($additionalFields !== NULL) {
+      $params['fl'] = 'PID' . ',' . implode(",", $additionalFields);
+    }
+    $params['wt'] = 'json';
+    return $this->solrBase . "/select?" . build_query($params, FALSE);
+  }
+
+}


### PR DESCRIPTION
This pull request contains all changes and additions to be able to migrate from Islandora 7 to Islandora 8 for student theses of the Leiden University Library.
The changes are:
- update for Drupal 9
- make it work with (different) namespaces
- only retrieve a single record per unique value for a Solr field
- exclude specific datastreams if configured
- add hash64 value for every field and full item

The additions are:
- Add data parser plugin that retrieves datastream metadata from Solr
- Add process plugin that checks and adapt the value in an array
- Add process plugin that zips 2 or more arrays
- Add data fetcher plugin that loads managed content inside a FoXML
- Add process plugin that returns part of XML by using an XPath